### PR TITLE
Clear RTC bit

### DIFF
--- a/src/AB1805_RK.cpp
+++ b/src/AB1805_RK.cpp
@@ -127,8 +127,10 @@ bool AB1805::resetConfig(uint32_t flags) {
 
     // Reset configuration registers to default values
     writeRegister(REG_STATUS, REG_STATUS_DEFAULT, false);
+    bool isRTCBitClear = isBitClear(REG_CTRL_1, REG_CTRL_1_WRTC, false);
     writeRegister(REG_CTRL_1, REG_CTRL_1_DEFAULT, false);
-    clearRegisterBit(REG_CTRL_1, REG_CTRL_1_WRTC, false);
+    if(isRTCBitClear) // Restore RTC bit to proper state
+        clearRegisterBit(REG_CTRL_1, REG_CTRL_1_WRTC, false);
     writeRegister(REG_CTRL_2, REG_CTRL_2_DEFAULT, false);
     writeRegister(REG_INT_MASK, REG_INT_MASK_DEFAULT, false);
     writeRegister(REG_SQW, REG_SQW_DEFAULT, false);

--- a/src/AB1805_RK.cpp
+++ b/src/AB1805_RK.cpp
@@ -128,6 +128,7 @@ bool AB1805::resetConfig(uint32_t flags) {
     // Reset configuration registers to default values
     writeRegister(REG_STATUS, REG_STATUS_DEFAULT, false);
     writeRegister(REG_CTRL_1, REG_CTRL_1_DEFAULT, false);
+    clearRegisterBit(REG_CTRL_1, REG_CTRL_1_WRTC, false);
     writeRegister(REG_CTRL_2, REG_CTRL_2_DEFAULT, false);
     writeRegister(REG_INT_MASK, REG_INT_MASK_DEFAULT, false);
     writeRegister(REG_SQW, REG_SQW_DEFAULT, false);


### PR DESCRIPTION
Clears WRTC bit in CTRL1 Register so RTC value can be read

<img width="827" alt="image" src="https://user-images.githubusercontent.com/46975667/217352263-b17f7038-8a44-4eb2-9dd7-c21d6373a741.png">
