### PR TITLE
Level interrupts

### DIFF
--- a/src/AB1805_RK.cpp
+++ b/src/AB1805_RK.cpp
@@ -546,7 +546,7 @@ bool AB1805::deepPowerDown(int seconds, bool loopToSleep) {
     }
 #endif
 
-    bResult = setCountdownTimer(seconds, false);
+    bResult = setCountdownTimer(seconds, false, true);
     if (!bResult) {
         _log.error(errorMsg, __LINE__);
         return false;

--- a/src/AB1805_RK.cpp
+++ b/src/AB1805_RK.cpp
@@ -496,7 +496,7 @@ bool AB1805::interruptCountdownTimer(int value, bool minutes) {
     return true;
 }
 
-bool AB1805::deepPowerDown(int seconds) {
+bool AB1805::deepPowerDown(int seconds, bool loopToSleep) {
     static const char *errorMsg = "failure in deepPowerDown %d";
     bool bResult;
 
@@ -583,15 +583,17 @@ bool AB1805::deepPowerDown(int seconds) {
     }
 
     // _log.trace("delay in case we didn't power down");   
-    unsigned long start = millis();
-    while(millis() - start < (unsigned long) (seconds * 1000)) {
-        _log.info("REG_SLEEP_CTRL=0x%2x", readRegister(REG_SLEEP_CTRL));
-        delay(1000);
+    if(loopToSleep) {
+        unsigned long start = millis();
+        while(millis() - start < (unsigned long) (seconds * 1000)) {
+            _log.info("REG_SLEEP_CTRL=0x%2x", readRegister(REG_SLEEP_CTRL));
+            delay(1000);
+        }
     }
 
     _log.error("didn't power down");
     delay(10);
-    System.reset();
+    // System.reset();
 
     return true;
 }
@@ -656,7 +658,7 @@ bool AB1805::checkVBAT(uint8_t mask, bool &isAbove) {
 
 
 
-bool AB1805::setCountdownTimer(int value, bool minutes) {
+bool AB1805::setCountdownTimer(int value, bool minutes, bool level) {
     static const char *errorMsg = "failure in setCountdownTimer %d";
     bool bResult;
 
@@ -698,7 +700,10 @@ bool AB1805::setCountdownTimer(int value, bool minutes) {
     uint8_t tfs = (minutes ? REG_TIMER_CTRL_TFS_1_60 : REG_TIMER_CTRL_TFS_1);
 
     // Enable countdown timer (TE = 1) in countdown timer control register
-    bResult = writeRegister(REG_TIMER_CTRL, REG_TIMER_CTRL_TE | tfs);
+    if(level)
+        bResult = writeRegister(REG_TIMER_CTRL, REG_TIMER_CTRL_TE | tfs | REG_TIMER_CTRL_TM);
+    else
+        bResult = writeRegister(REG_TIMER_CTRL, REG_TIMER_CTRL_TE | tfs);
     if (!bResult) {
         _log.error(errorMsg, __LINE__);
         return false;

--- a/src/AB1805_RK.cpp
+++ b/src/AB1805_RK.cpp
@@ -593,7 +593,6 @@ bool AB1805::deepPowerDown(int seconds, bool loopToSleep) {
 
     _log.error("didn't power down");
     delay(10);
-    // System.reset();
 
     return true;
 }

--- a/src/AB1805_RK.h
+++ b/src/AB1805_RK.h
@@ -309,6 +309,9 @@ public:
      * 
      * @param seconds number of seconds to power down. Must be 0 < seconds <= 255.
      * The default is 30 seconds. If time-sensitive, 10 seconds is probably sufficient.
+     *
+     * @param loopToSleep if True, will loop until falls asleep or time elapses, else
+     * return immediatly
      * 
      * @return true on success or false if an error occurs.
      * 
@@ -324,7 +327,7 @@ public:
      * 
      * This works even if the RTC has not been set yet.
      */
-    bool deepPowerDown(int seconds = 30);
+    bool deepPowerDown(int seconds = 30, bool loopToSleep=true);
 
     /**
      * @brief Used internally by interruptCountdownTimer and deepPowerDown.
@@ -332,13 +335,16 @@ public:
      * @param value Value in seconds or minutes. Must be 0 < value <= 255! 
      * 
      * @param minutes True if minutes, false if seconds
+     *
+     * @param level True means the timer interrupt will act as a level shift rather
+     * than a pulse
      * 
      * @return true on success or false if an error occurs.
      * 
      * The countdown timer works even if the RTC has not been set yet, but is more
      * limited in range (maximum: 255 minutes).
      */
-    bool setCountdownTimer(int value, bool minutes);
+    bool setCountdownTimer(int value, bool minutes, bool level = false);
 
     /**
      * @brief Stops the interruptCountdownTimer


### PR DESCRIPTION
Give setCountTimer the option to use a level interrupt rather than a pulse
Gives deepPowerDown option to return instead of looping if it doesn't go to sleep right away
deepPowerDown to use level interrupt